### PR TITLE
Multi code configuration for trackables, and connect configuration with backend

### DIFF
--- a/homeassistant/components/geocaching/const.py
+++ b/homeassistant/components/geocaching/const.py
@@ -42,3 +42,11 @@ class GeocacheCategory(Enum):
 GEOCACHING_ID_SENSOR_FORMAT = DOMAIN + ".{}_{}"
 CACHE_ID_SENSOR_FORMAT = DOMAIN + ".{}_{}_{}"
 TRACKABLE_ID_SENSOR_FORMAT = DOMAIN + ".{}_{}"
+
+# Section IDs for the config flow
+CONFIG_FLOW_GEOCACHES_SECTION_ID = "tracked_geocache_ids"
+CONFIG_FLOW_TRACKABLES_SECTION_ID = "tracked_trackable_ids"
+
+# TODO: Remove this temporary variable, only used during development | pylint: disable=fixme
+# Enabling this will skip the entire tracked objects configuration process and use predefined codes
+USE_TEST_CONFIG: bool = True

--- a/homeassistant/components/geocaching/coordinator.py
+++ b/homeassistant/components/geocaching/coordinator.py
@@ -17,7 +17,15 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN, ENVIRONMENT, LOGGER, UPDATE_INTERVAL
+from .const import (
+    CONFIG_FLOW_GEOCACHES_SECTION_ID,
+    CONFIG_FLOW_TRACKABLES_SECTION_ID,
+    DOMAIN,
+    ENVIRONMENT,
+    LOGGER,
+    UPDATE_INTERVAL,
+    USE_TEST_CONFIG,
+)
 
 
 class GeocachingDataUpdateCoordinator(DataUpdateCoordinator[GeocachingStatus]):
@@ -50,11 +58,24 @@ class GeocachingDataUpdateCoordinator(DataUpdateCoordinator[GeocachingStatus]):
                 radiusKm=3,
             )
         )
-        # TODO: Read this from the config | pylint: disable=fixme
-        settings.set_trackables(["TB89YPV"])
 
-        # TODO: Read this from the config | pylint: disable=fixme
-        settings.set_caches(["GC1DQPM", "GC9P6FN"])
+        # TODO: Remove the hardcoded codes when development is done | pylint: disable=fixme
+        trackable_codes: list[str] = (
+            ["TB89YPV"]
+            if USE_TEST_CONFIG
+            else self.entry.data[CONFIG_FLOW_TRACKABLES_SECTION_ID]
+        )
+        # TODO: Validate the trackable reference codes | pylint: disable=fixme
+        settings.set_trackables(trackable_codes)
+
+        # TODO: Remove the hardcoded codes when development is done | pylint: disable=fixme
+        geocache_codes: list[str] = (
+            ["GC1DQPM", "GC9P6FN"]
+            if USE_TEST_CONFIG
+            else self.entry.data[CONFIG_FLOW_GEOCACHES_SECTION_ID]
+        )
+        # TODO: Validate the geocache reference codes | pylint: disable=fixme
+        settings.set_caches(geocache_codes)
 
         self.geocaching = GeocachingApi(
             environment=ENVIRONMENT,

--- a/homeassistant/components/geocaching/strings.json
+++ b/homeassistant/components/geocaching/strings.json
@@ -7,6 +7,20 @@
       "reauth_confirm": {
         "title": "[%key:common::config_flow::title::reauth%]",
         "description": "The Geocaching integration needs to re-authenticate your account"
+      },
+      "additional_config": {
+        "title": "Configure tracked objects",
+        "description": "The integration can track caches and trackables, for which entities will be generated",
+        "sections": {
+          "tracked_geocache_ids": {
+            "name": "Tracked Geocaches",
+            "description": "Optionally add geocaches to track"
+          },
+          "tracked_trackable_ids": {
+            "name": "Tracked Trackables",
+            "description": "Optionally add trackables to track"
+          }
+        }
       }
     },
     "abort": {


### PR DESCRIPTION
* Connect configuration with backend so that the user configured trackable codes are used
* Add support for selecting multiple codes to track

Note: The temporary variable `USE_TEST_CONFIG` decides whether the code configuration step will be performed or if it will be skipped and predefined codes will be used instead. This is in place temporarily to speed up development