### PR TITLE
Replace cache find count entity with found date and found switch

### DIFF
--- a/homeassistant/components/geocaching/coordinator.py
+++ b/homeassistant/components/geocaching/coordinator.py
@@ -70,7 +70,7 @@ class GeocachingDataUpdateCoordinator(DataUpdateCoordinator[GeocachingStatus]):
 
         # TODO: Remove the hardcoded codes when development is done | pylint: disable=fixme
         geocache_codes: list[str] = (
-            ["GC1DQPM", "GC9P6FN"]
+            ["GC1DQPM", "GC9P6FN", "GCAKTTQ"]
             if USE_TEST_CONFIG
             else self.entry.data[CONFIG_FLOW_GEOCACHES_SECTION_ID]
         )

--- a/homeassistant/components/geocaching/icons.json
+++ b/homeassistant/components/geocaching/icons.json
@@ -28,17 +28,20 @@
       "cache_owner": {
         "default": "mdi:account"
       },
-      "cache_location": {
-        "default": "mdi:map-marker"
+      "cache_found_date": {
+        "default": "mdi:calendar-search"
       },
-      "cache_find_count": {
-        "default": "mdi:eye-check-outline"
+      "cache_found": {
+        "default": "mdi:package-variant-closed-check"
       },
       "cache_favorite_points": {
         "default": "mdi:star-check"
       },
       "cache_hide_date": {
-        "default": "mdi:calendar-range"
+        "default": "mdi:calendar-badge"
+      },
+      "cache_location": {
+        "default": "mdi:map-marker"
       },
       "trackable_name": {
         "default": "mdi:label"
@@ -56,7 +59,7 @@
         "default": "mdi:package-variant-closed"
       },
       "trackable_release_date": {
-        "default": "mdi:calendar-range"
+        "default": "mdi:calendar-badge"
       }
     }
   }

--- a/homeassistant/components/geocaching/strings.json
+++ b/homeassistant/components/geocaching/strings.json
@@ -56,17 +56,20 @@
       "cache_owner": {
         "name": "Owner"
       },
-      "cache_location": {
-        "name": "Location"
+      "cache_found_date": {
+        "name": "Found date"
       },
-      "cache_find_count": {
-        "name": "Find count"
+      "cache_found": {
+        "name": "Found"
       },
       "cache_favorite_points": {
         "name": "Favorite points"
       },
       "cache_hide_date": {
         "name": "Hide date"
+      },
+      "cache_location": {
+        "name": "Location"
       },
       "trackable_name": {
         "name": "Name"


### PR DESCRIPTION
* Remove cache find count as it is only available on full Geocaches, and calculating it manually through cache log requests would generate many more requests for so little data, and require support for pagination
* Add cache found date entity, tied to user
* Add cache found entity, tied to user